### PR TITLE
QoL and a few bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ haos_proxmox_name: homeassistant
 haos_proxmox_onboot: yes
 haos_proxmox_protection: yes
 haos_proxmox_sockets: 1
+haos_proxmox_storage: local
+haos_proxmox_storage_interface: sata0
 ```
 
 Several VM attributes.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,5 @@ haos_proxmox_onboot: yes
 haos_proxmox_protection: yes
 haos_proxmox_sockets: 1
 haos_proxmox_storage: local
+haos_proxmox_storage_size: 64G
+haos_proxmox_storage_interface: sata0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,5 +10,4 @@ haos_proxmox_onboot: yes
 haos_proxmox_protection: yes
 haos_proxmox_sockets: 1
 haos_proxmox_storage: local
-haos_proxmox_storage_size: 64G
 haos_proxmox_storage_interface: sata0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -111,6 +111,10 @@
     cmd: 'qm set {{ haos_vm.vmid }} --boot order={{ haos_proxmox_storage_interface }}'
   become: true
 
+- name: Wait for changes to apply
+  wait_for:
+    timeout: 5
+
 - name: Start VM
   community.general.proxmox_kvm:
     api_host: '{{ ansible_host }}'
@@ -119,6 +123,7 @@
     name: '{{ haos_proxmox_name }}'
     node: '{{ haos_proxmox_node }}'
     state: started
+    timeout: 300
 
 - name: Cleanup tmp dir
   ansible.builtin.file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,11 @@
+- name: Install packages required by proxmox_kvm module
+  ansible.builtin.apt:
+    pkg:
+    - python3-proxmoxer
+    - python3-requests
+    - xz-utils
+  become: true
+
 - name: Create temporary directory
   ansible.builtin.tempfile:
     state: directory
@@ -12,7 +20,7 @@
 
 - name: Determine relevant asset for latest release (json containing image name and url)
   set_fact:
-    haos_release: '{{ haos_releases.json | json_query("[?prerelease == `false`] | [0].assets[?contains(name, `vmdk`)] | [0]") }}'
+    haos_release: '{{ haos_releases.json | json_query("[?prerelease == `false`] | [0].assets[?contains(name, `qcow2`)] | [?contains(name, `ova`)] | [0]") }}'
 
 - name: Download Home Assistant disk image
   get_url:
@@ -20,21 +28,14 @@
     dest: '{{ haos_tempdir.path }}/{{ haos_release.name }}'
 
 - name: Unarchive downloaded image
-  ansible.builtin.unarchive:
-    src: '{{ haos_tempdir.path }}/{{ haos_release.name }}'
-    dest: '{{ haos_tempdir.path }}'
-    remote_src: true
+  ansible.builtin.command:
+    cmd: 'unxz {{ src }}'
+  vars:
+    src: "{{ haos_tempdir.path }}/{{ haos_release.name }}"
 
 - name: Determine image filename (downloaded file without the zip extension)
   set_fact:
-    haos_image_filename: '{{ haos_release.name | regex_search(".*\.vmdk") }}'
-
-- name: Install packages required by proxmox_kvm module
-  ansible.builtin.apt:
-    pkg:
-    - python3-proxmoxer
-    - python3-requests
-  become: true
+    haos_image_filename: '{{ haos_release.name | regex_search(".*\.qcow2") }}'
 
 - name: Determine network adaptor string when MAC address is specified
   set_fact:
@@ -56,6 +57,7 @@
     cores: '{{ haos_proxmox_cores }}'
     description: '{{ haos_proxmox_description }}'
     localtime: true
+    machine: q35
     memory: '{{ haos_proxmox_memory }}'
     name: '{{ haos_proxmox_name }}'
     net:
@@ -97,7 +99,7 @@
   set_fact:
     haos_setdisk_cmd:
       zfspool: 'qm set {{ haos_vm.vmid }} --{{ haos_proxmox_storage_interface }} {{ haos_proxmox_storage }}:vm-{{ haos_vm.vmid }}-disk-1'
-      dir: 'qm set {{ haos_vm.vmid }} --{{ haos_proxmox_storage_interface }} {{ haos_proxmox_storage }}:{{ haos_vm.vmid }}/vm-{{ haos_vm.vmid }}-disk-1.qcow2,size={{ haos_proxmox_storage_size }}'
+      dir: 'qm set {{ haos_vm.vmid }} --{{ haos_proxmox_storage_interface }} {{ haos_proxmox_storage }}:{{ haos_vm.vmid }}/vm-{{ haos_vm.vmid }}-disk-1.qcow2'
 
 - name: Have VM use the imported image
   ansible.builtin.command:
@@ -108,3 +110,17 @@
   ansible.builtin.command:
     cmd: 'qm set {{ haos_vm.vmid }} --boot order={{ haos_proxmox_storage_interface }}'
   become: true
+
+- name: Start VM
+  community.general.proxmox_kvm:
+    api_host: '{{ ansible_host }}'
+    api_password: '{{ haos_proxmox_api_password }}'
+    api_user: '{{ haos_proxmox_api_user }}'
+    name: '{{ haos_proxmox_name }}'
+    node: '{{ haos_proxmox_node }}'
+    state: started
+
+- name: Cleanup tmp dir
+  ansible.builtin.file:
+    path: "{{ haos_tempdir.path }}"
+    state: absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -106,5 +106,5 @@
 
 - name: Set boot order
   ansible.builtin.command:
-    cmd: 'qm set 115 --boot order=sata0'
+    cmd: 'qm set {{ haos_vm.vmid }} --boot order=sata0'
   become: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -96,8 +96,8 @@
 - name: Set disk command depends on storage type
   set_fact:
     haos_setdisk_cmd:
-      zfspool: 'qm set {{ haos_vm.vmid }} --sata0 {{ haos_proxmox_storage }}:vm-{{ haos_vm.vmid }}-disk-1'
-      dir: 'qm set {{ haos_vm.vmid }} --sata0 {{ haos_proxmox_storage }}:{{ haos_vm.vmid }}/vm-{{ haos_vm.vmid }}-disk-1.qcow2,size=6G'
+      zfspool: 'qm set {{ haos_vm.vmid }} --{{ haos_proxmox_storage_interface }} {{ haos_proxmox_storage }}:vm-{{ haos_vm.vmid }}-disk-1'
+      dir: 'qm set {{ haos_vm.vmid }} --{{ haos_proxmox_storage_interface }} {{ haos_proxmox_storage }}:{{ haos_vm.vmid }}/vm-{{ haos_vm.vmid }}-disk-1.qcow2,size={{ haos_proxmox_storage_size }}'
 
 - name: Have VM use the imported image
   ansible.builtin.command:
@@ -106,5 +106,5 @@
 
 - name: Set boot order
   ansible.builtin.command:
-    cmd: 'qm set {{ haos_vm.vmid }} --boot order=sata0'
+    cmd: 'qm set {{ haos_vm.vmid }} --boot order={{ haos_proxmox_storage_interface }}'
   become: true


### PR DESCRIPTION
I had to make a few changes in order to get the created VM to boot properly, not sure if the vmdk is working for you but I kept getting stuck at the EFI shell. I was following this site to update to the q35 machine type and using the ova qcow2 image instead of the generic vmdk image. I was using [this guide](https://blog.habitats.tech/howto-install-home-assistant-ha-os-in-proxmox-ve-pve-71) to cross-reference the install steps with the tasks provided in this role.

Updates I made to make it boot:

- q35 machine type
- use qcow2 ova image instead of generic vmdk
  - This required the change from a zip to xz to unarchive the downloaded file
  - Also added the xz-utils package because of this change, running proxmox on a base Debian 10 does not have xz installed by default. Moved the package install to be before downloading the image
- Replace hard-coded vmid with variable

A couple of quality of life changes I made to hopefully improve the usability:

- Added variable for storage interface (I prefer to use the scsi0 interface, but kept the sata0 interface as the default variable)
- Removed the size when importing the disk because the image will be the size that it was configured with in the ova that is downloaded. Looks to be related to issue #10 and #11. Probably would need a separate task before the VM is started to resize the disk somehow but I will leave that for a later time. The qcow2 appears to be 32GB by default. When it was set to the vmdk and not booting, the disk was showing as 6GB no matter what I set the size to, could just be a difference in image types.
- Added task to start the VM once everything was configured. Maybe a future improvement would be to add a variable/condition to allow the user to disable this in the future? If you feel that functionality would be necessary from the start, I can look into adding that if needed.
- Added a task to cleanup the tmp directory that is created at the beginning. I had more than a few copies of the downloaded disk image by the time I was done testing :smile: 


Let me know if there is anything you would like me to change for this pull request. I have been on the search for an ansible role that deploys home assistant this way. My current setup has been running with the qcow2/ova image in a proxmox VM for about 2 years now and working great, glad to see there is a role out there that deploys in this configuration! Thanks!